### PR TITLE
設定画面の機能の実装

### DIFF
--- a/src/components/game/SettingMenu.tsx
+++ b/src/components/game/SettingMenu.tsx
@@ -1,7 +1,7 @@
 'use client'
-import Image from 'next/image'
-import { useState, useRef } from 'react'
+import Image from 'next/image';
 import Link from "next/link";
+import { useRef, useState } from 'react';
 import { useAuth } from "../../context/AuthContext";
 
 function MenuButton({
@@ -105,7 +105,7 @@ export default function SettingsMenu({
                 />
               </div>
               <Link href="/" className="py-2 px-8 text-2xl text-white font-bold bg-[#5B7BA6] rounded-md">
-                戻る
+                はい
               </Link>
             </div>
           </div>


### PR DESCRIPTION
設定画面の機能の実装を行いました。
アカウント情報の画面ではログインしているアカウントのメールアドレスが表示されます。
「ホームに戻る」からホームに戻れます。
右上の×ボタンとデザインの「閉じる」や「キャンセル」ボタンは機能が重複していると思ったので、まだ実装していません。必要であれば教えてください。すぐやります。
<img width="935" height="433" alt="スクリーンショット 2025-10-23 13 57 49" src="https://github.com/user-attachments/assets/ac4c7d60-fe8e-458a-96c5-af94260ff775" />
<img width="936" height="433" alt="スクリーンショット 2025-10-23 13 58 02" src="https://github.com/user-attachments/assets/cca811f7-6414-4e59-b259-0cacca4fae61" />
<img width="934" height="432" alt="スクリーンショット 2025-10-23 13 58 11" src="https://github.com/user-attachments/assets/17c3fed0-1f75-4af2-8814-474bacc90d80" />
